### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -33,5 +33,5 @@ xWindow			KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-cross LITERAL1
-undo  LITERAL1
+cross	LITERAL1
+undo	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords