### PR TITLE
Revert library name change

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=ESP8266 emGUI
+name=emGUI
 version=1.0.0
 author=romansavrulin <romansavrulin@gmail.com>, MikhailNatalenko <mikhailnatalenko@ya.ru>
 maintainer=romansavrulin <romansavrulin@gmail.com>, MikhailNatalenko <mikhailnatalenko@ya.ru>


### PR DESCRIPTION
Libraries are locked to the `name` value specified by the library.properties metadata file in the release at the time of
the Library Manager submission.

Any release with a different name is rejected by the Arduino Library Manager indexer:
https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ#why-arent-releases-of-my-library-being-picked-up-by-library-manager

As an alternative to this proposal, you can request the name change in the index:
https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ#how-can-i-change-my-librarys-name